### PR TITLE
Atomic get&set to avoid repeats.

### DIFF
--- a/lib/dont_repeat_for.rb
+++ b/lib/dont_repeat_for.rb
@@ -24,19 +24,23 @@ class DontRepeatFor
 
     return nil if ran_recently?
 
-    remember_not_to_repeat!
+    set_key_expiry
 
     yield
   end
 
   private
 
-  def remember_not_to_repeat!
-    redis.set(storage_key, true, ex: time)
+  def set_key_expiry
+    redis.expire(storage_key, time)
   end
 
+  ##
+  # Using an incr to atomically get & set the value.
+  # If incr === 1 then the key was empty before incrementing
+  # Otherwise, it has already been incremented before expiring
   def ran_recently?
-    redis.get(storage_key)
+    redis.incr(storage_key) != 1
   end
 
   def storage_key

--- a/lib/dont_repeat_for/version.rb
+++ b/lib/dont_repeat_for/version.rb
@@ -1,3 +1,3 @@
 class DontRepeatFor
-    VERSION = '1.0.0.0'
+    VERSION = '1.0.0.1'
 end


### PR DESCRIPTION
# why
The goal of this gem is to create a simple flag system that avoids repeats. It currently does not do that.
# what
Use the incr command which will atomically increment as well as returns the state of the variable. This is the vital operation necessary for sharing state across threads.

# future improvements
We could also move the whole logic of this operation to LUA. That would allow control over the exceptional case where the incr occurs but redis crashes before allowing the expiry to be set, leaking a key forever.