### PR TITLE
Add version history for non-compatible keys

### DIFF
--- a/lib/dont_repeat_for.rb
+++ b/lib/dont_repeat_for.rb
@@ -44,7 +44,7 @@ class DontRepeatFor
   end
 
   def storage_key
-    @storage_key ||= "DontRepeatFor/Keys/#{@key}"
+    @storage_key ||= "DontRepeatFor/v1/Keys/#{@key}"
   end
 
   def redis


### PR DESCRIPTION
# why
It is probably important to forcefully expire keys occasionally if we make non-compatible changes, like I just did.